### PR TITLE
bin/release is corrected so this can work under Diego runtime.

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,7 +1,3 @@
 #!/bin/bash
 
-cat <<EOF
----
-addons:
-default_process_types:
-EOF
+echo -e "---\ndefault_process_types:\n  web: exit 1"


### PR DESCRIPTION
In accordance to official Cloud Foundry buildpacks documentation bin/compile should return script compatible to Heroku Procfile. https://docs.cloudfoundry.org/buildpacks/custom.html#release-script
In Cloud Foundry with Diego runtime this is really checked.

Cloud Foundry 'binary' buildpack is known highly compatible solution. Its bin/release is pretty standard illustration of 'doing nothing' release script. https://github.com/cloudfoundry/binary-buildpack/blob/master/bin/release

This change just transfers appropriate CF official binary buildpack release script into mono buildpack. So now Diego can handle it. It was checked that buildpack runs after it on CF v236 (both DEA and Diego runtime) as well as current Heroku platform (2016.07.03).
